### PR TITLE
Mergeing branches, stability improvements, configurable simulation

### DIFF
--- a/config/jog_settings.yaml
+++ b/config/jog_settings.yaml
@@ -1,5 +1,5 @@
 jog_arm_server:
-  simu: false
+  simu: false # Whether the robot is started in simulation environment
   cmd_in_topic:  jog_arm_server/delta_jog_cmds
   cmd_frame:  base_link  # TF frame that incoming cmds are given in
   incoming_cmd_timeout:  5  # Stop jogging if X seconds elapse without a new cmd

--- a/config/jog_settings.yaml
+++ b/config/jog_settings.yaml
@@ -1,6 +1,6 @@
 jog_arm_server:
   cmd_in_topic:  jog_arm_server/delta_jog_cmds
-  incoming_cmd_timeout:  0.25  # Stop jogging if X seconds elapse without a new cmd
+  incoming_cmd_timeout:  5  # Stop jogging if X seconds elapse without a new cmd
   joint_topic:  joint_states
   move_group_name:  right_ur5
   singularity_threshold:  5.5  # Slow down when the condition number hits this (close to singularity)

--- a/config/jog_settings.yaml
+++ b/config/jog_settings.yaml
@@ -1,4 +1,5 @@
 jog_arm_server:
+  simu: false
   cmd_in_topic:  jog_arm_server/delta_jog_cmds
   cmd_frame:  base_link  # TF frame that incoming cmds are given in
   incoming_cmd_timeout:  5  # Stop jogging if X seconds elapse without a new cmd

--- a/config/jog_settings.yaml
+++ b/config/jog_settings.yaml
@@ -1,4 +1,5 @@
 jog_arm_server:
+  simu: false
   cmd_in_topic:  jog_arm_server/delta_jog_cmds
   incoming_cmd_timeout:  5  # Stop jogging if X seconds elapse without a new cmd
   joint_topic:  joint_states

--- a/include/jog_arm_server.h
+++ b/include/jog_arm_server.h
@@ -79,7 +79,7 @@ void joints_cb(const sensor_msgs::JointStateConstPtr& msg);
 
 // ROS params to be read
 int readParams(ros::NodeHandle& n);
-std::string move_group_name, joint_topic, cmd_in_topic, cmd_out_topic, planning_frame;
+std::string move_group_name, joint_topic, cmd_in_topic, input_frame, cmd_out_topic, planning_frame;
 double linear_scale, rot_scale, singularity_threshold, hard_stop_sing_thresh, low_pass_filter_coeff, pub_period, incoming_cmd_timeout;
 
 std::string getStringParam(std::string s, ros::NodeHandle& n);

--- a/include/jog_arm_server.h
+++ b/include/jog_arm_server.h
@@ -81,10 +81,11 @@ void joints_cb(const sensor_msgs::JointStateConstPtr& msg);
 int readParams(ros::NodeHandle& n);
 std::string move_group_name, joint_topic, cmd_in_topic, input_frame, cmd_out_topic, planning_frame;
 double linear_scale, rot_scale, singularity_threshold, hard_stop_sing_thresh, low_pass_filter_coeff, pub_period, incoming_cmd_timeout;
+bool simu;
 
 std::string getStringParam(std::string s, ros::NodeHandle& n);
 double getDoubleParam(std::string name, ros::NodeHandle& n);
-
+bool getBoolParam(std::string name, ros::NodeHandle& n);
 /**
  * Class lpf - Filter the joint velocities to avoid jerky motion.
  */

--- a/include/jog_arm_server.h
+++ b/include/jog_arm_server.h
@@ -81,10 +81,11 @@ void joints_cb(const sensor_msgs::JointStateConstPtr& msg);
 int readParams(ros::NodeHandle& n);
 std::string move_group_name, joint_topic, cmd_in_topic, cmd_frame, cmd_out_topic, planning_frame;
 double linear_scale, rot_scale, singularity_threshold, hard_stop_sing_thresh, low_pass_filter_coeff, pub_period, incoming_cmd_timeout;
+bool simu;
 
 std::string getStringParam(std::string s, ros::NodeHandle& n);
 double getDoubleParam(std::string name, ros::NodeHandle& n);
-
+bool getBoolParam(std::string name, ros::NodeHandle& n);
 /**
  * Class lpf - Filter the joint velocities to avoid jerky motion.
  */

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -65,6 +65,10 @@ int main(int argc, char **argv)
   ros::Publisher joint_trajectory_pub = n.advertise<trajectory_msgs::JointTrajectory>(jog_arm::cmd_out_topic, 1);
 
   ros::topic::waitForMessage<sensor_msgs::JointState>(jog_arm::joint_topic);
+  ros::topic::waitForMessage<geometry_msgs::TwistStamped>(jog_arm::cmd_in_topic);
+
+  //Wait for jog filter to stablize
+  ros::Duration(1).sleep();
 
   while( ros::ok() )
   {
@@ -121,6 +125,7 @@ CollisionCheck::CollisionCheck(std::string move_group_name)
   // Wait for initial joint message
   ROS_WARN_STREAM("[jog_arm_server CollisionCheck] Waiting for first joint msg.");
   ros::topic::waitForMessage<sensor_msgs::JointState>(jog_arm::joint_topic);
+  ros::topic::waitForMessage<geometry_msgs::TwistStamped>(jog_arm::cmd_in_topic);
 
   pthread_mutex_lock(&joints_mutex);
   sensor_msgs::JointState jts = jog_arm::joints;
@@ -190,7 +195,8 @@ JogCalcs::JogCalcs(std::string move_group_name) :
   // Wait for initial messages
   ROS_WARN_STREAM("[jog_arm_server JogCalcs] Waiting for first joint msg.");
   ros::topic::waitForMessage<sensor_msgs::JointState>(jog_arm::joint_topic);
-  
+  ros::topic::waitForMessage<geometry_msgs::TwistStamped>(jog_arm::cmd_in_topic);
+
   jt_state_.name = arm_.getJointNames();
   jt_state_.position.resize(jt_state_.name.size());
   jt_state_.velocity.resize(jt_state_.name.size());

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -236,7 +236,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   try {
     listener_.waitForTransform( cmd.header.frame_id, jog_arm::planning_frame, ros::Time::now(), ros::Duration(0.2) );
   } catch (tf::TransformException ex) {
-    ROS_ERROR("[jog_arm_server jogCalcs] - Failed to transform command to planning frame.");
+    ROS_ERROR_STREAM("[jog_arm_server jogCalcs: " << ex.what());
     return;
   }
   // To transform, these vectors need to be stamped. See answers.ros.org Q#199376 (Annoying! Maybe do a PR.)
@@ -244,12 +244,22 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   geometry_msgs::Vector3Stamped lin_vector;
   lin_vector.vector = cmd.twist.linear;
   lin_vector.header.frame_id = cmd.header.frame_id;
-  listener_.transformVector(jog_arm::planning_frame, lin_vector, lin_vector);
+  try {
+    listener_.transformVector(jog_arm::planning_frame, lin_vector, lin_vector);
+  } catch (tf::TransformException ex) {
+    ROS_ERROR_STREAM("[jog_arm_server jogCalcs: " << ex.what());
+    return;    
+  }
   
   geometry_msgs::Vector3Stamped rot_vector;
   rot_vector.vector = cmd.twist.angular;
   rot_vector.header.frame_id = cmd.header.frame_id;
-  listener_.transformVector(jog_arm::planning_frame, rot_vector, rot_vector);
+  try {
+    listener_.transformVector(jog_arm::planning_frame, rot_vector, rot_vector);
+  } catch (tf::TransformException ex) {
+    ROS_ERROR_STREAM("[jog_arm_server jogCalcs: " << ex.what());
+    return;    
+  }
   
   // Put these components back into a TwistStamped
   geometry_msgs::TwistStamped twist_cmd;

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -65,6 +65,10 @@ int main(int argc, char **argv)
   ros::Publisher joint_trajectory_pub = n.advertise<trajectory_msgs::JointTrajectory>(jog_arm::cmd_out_topic, 1);
 
   ros::topic::waitForMessage<sensor_msgs::JointState>(jog_arm::joint_topic);
+  ros::topic::waitForMessage<geometry_msgs::TwistStamped>(jog_arm::cmd_in_topic);
+
+  //Wait for jog filter to stablize
+  ros::Duration(1).sleep();
 
   while( ros::ok() )
   {
@@ -120,6 +124,7 @@ CollisionCheck::CollisionCheck(std::string move_group_name)
   // Wait for initial joint message
   ROS_WARN_STREAM("[jog_arm_server CollisionCheck] Waiting for first joint msg.");
   ros::topic::waitForMessage<sensor_msgs::JointState>(jog_arm::joint_topic);
+  ros::topic::waitForMessage<geometry_msgs::TwistStamped>(jog_arm::cmd_in_topic);
 
   pthread_mutex_lock(&joints_mutex);
   sensor_msgs::JointState jts = jog_arm::joints;
@@ -189,7 +194,8 @@ JogCalcs::JogCalcs(std::string move_group_name) :
   // Wait for initial messages
   ROS_WARN_STREAM("[jog_arm_server JogCalcs] Waiting for first joint msg.");
   ros::topic::waitForMessage<sensor_msgs::JointState>(jog_arm::joint_topic);
-  
+  ros::topic::waitForMessage<geometry_msgs::TwistStamped>(jog_arm::cmd_in_topic);
+
   jt_state_.name = arm_.getJointNames();
   jt_state_.position.resize(jt_state_.name.size());
   jt_state_.velocity.resize(jt_state_.name.size());

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -312,9 +312,15 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
 
   // Spam several redundant points into the trajectory. The first few may be skipped if the
   // time stamp is in the past when it reaches the client.
-  for (int i=1; i<20; i++)
-  {
-    point.time_from_start = ros::Duration(i*jog_arm::pub_period);
+  if (jog_arm::simu) {
+    // Spam several redundant points into the trajectory. The first few may be skipped if the
+    // time stamp is in the past when it reaches the client. Needed for gazebo simulation.
+    for (int i=1; i<30; i++)
+    {
+      point.time_from_start = ros::Duration(i*jog_arm::pub_period);
+      new_jt_traj.points.push_back(point);
+    }
+  } else {
     new_jt_traj.points.push_back(point);
   }
 
@@ -504,6 +510,8 @@ int readParams(ros::NodeHandle& n)
   ROS_INFO_STREAM("planning_frame: " << jog_arm::planning_frame);
   jog_arm::pub_period = jog_arm::getDoubleParam("jog_arm_server/pub_period", n);
   ROS_INFO_STREAM("pub_period: " << jog_arm::pub_period);
+  jog_arm::simu = jog_arm::getBoolParam("jog_arm_server/simu", n);
+  ROS_INFO_STREAM("simu: " << jog_arm::simu);
   ROS_INFO_STREAM("---------------------------------------");
   ROS_INFO_STREAM("---------------------------------------");
 
@@ -534,6 +542,14 @@ double getDoubleParam(std::string name, ros::NodeHandle& n)
   double value;
   if( !n.getParam(name, value) )
     ROS_ERROR_STREAM("[JogCalcs::getDoubleParam] YAML config file does not contain parameter " << name);
+  return value;
+}
+
+bool getBoolParam(std::string name, ros::NodeHandle& n)
+{
+  bool value;
+  if( !n.getParam(name, value) )
+    ROS_ERROR_STREAM("[JogCalcs::getBoolParam] YAML config file does not contain parameter " << name);
   return value;
 }
 

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -235,7 +235,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   try {
     listener_.waitForTransform( cmd.header.frame_id, jog_arm::planning_frame, ros::Time::now(), ros::Duration(0.2) );
   } catch (tf::TransformException ex) {
-    ROS_ERROR_STREAM("[jog_arm_server jogCalcs: " << ex.what());
+    ROS_ERROR_STREAM("[jog_arm_server jogCalcs 238: " << ex.what());
     return;
   }
   // To transform, these vectors need to be stamped. See answers.ros.org Q#199376 (Annoying! Maybe do a PR.)
@@ -246,7 +246,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   try {
     listener_.transformVector(jog_arm::planning_frame, lin_vector, lin_vector);
   } catch (tf::TransformException ex) {
-    ROS_ERROR_STREAM("[jog_arm_server jogCalcs: " << ex.what());
+    ROS_ERROR_STREAM("[jog_arm_server jogCalcs 249: " << ex.what());
     return;    
   }
   
@@ -256,7 +256,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   try {
     listener_.transformVector(jog_arm::planning_frame, rot_vector, rot_vector);
   } catch (tf::TransformException ex) {
-    ROS_ERROR_STREAM("[jog_arm_server jogCalcs: " << ex.what());
+    ROS_ERROR_STREAM("[jog_arm_server jogCalcs 259: " << ex.what());
     return;    
   }
   
@@ -307,7 +307,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   new_jt_traj.joint_names = jt_state_.name;
   trajectory_msgs::JointTrajectoryPoint point;
   point.positions = jt_state_.position;
-  point.time_from_start = ros::Durataion(jog_arm::pub_period);
+  point.time_from_start = ros::Duration(jog_arm::pub_period);
   point.velocities = jt_state_.velocity;
 
   // Spam several redundant points into the trajectory. The first few may be skipped if the
@@ -458,6 +458,7 @@ void delta_cmd_cb(const geometry_msgs::TwistStampedConstPtr& msg)
 {
   pthread_mutex_lock(&cmd_deltas_mutex);
   jog_arm::cmd_deltas = *msg;
+  jog_arm::cmd_deltas.header.frame_id = jog_arm::input_frame;
   pthread_mutex_unlock(&cmd_deltas_mutex);
 }
 
@@ -488,6 +489,8 @@ int readParams(ros::NodeHandle& n)
   ROS_INFO_STREAM("joint_topic: " << jog_arm::joint_topic);
   jog_arm::cmd_in_topic = jog_arm::getStringParam("jog_arm_server/cmd_in_topic", n);
   ROS_INFO_STREAM("cmd_in_topic: " << jog_arm::cmd_in_topic);
+  jog_arm::input_frame = jog_arm::getStringParam("jog_arm_server/input_frame", n);
+  ROS_INFO_STREAM("input frame: " << jog_arm::input_frame);
   jog_arm::incoming_cmd_timeout = jog_arm::getDoubleParam("jog_arm_server/incoming_cmd_timeout", n);
   ROS_INFO_STREAM("incoming_cmd_timeout: " << jog_arm::incoming_cmd_timeout);
   jog_arm::cmd_out_topic = jog_arm::getStringParam("jog_arm_server/cmd_out_topic", n);

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -316,8 +316,6 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   point.time_from_start = ros::Duration(jog_arm::pub_period);
   point.velocities = jt_state_.velocity;
 
-  // Spam several redundant points into the trajectory. The first few may be skipped if the
-  // time stamp is in the past when it reaches the client.
   if (jog_arm::simu) {
     // Spam several redundant points into the trajectory. The first few may be skipped if the
     // time stamp is in the past when it reaches the client. Needed for gazebo simulation.

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -353,7 +353,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   {
     if ( currentCN > jog_arm::hard_stop_sing_thresh )
     {
-      ROS_ERROR_THROTTLE(2,"[jog_arm_server jogCalcs] Dangerously close to a singularity. Halting.");
+      ROS_ERROR_THROTTLE(2,"[jog_arm_server jogCalcs] Dangerously close to a singularity (%f). Halting.", currentCN);
       for (int i=0; i<jt_state_.velocity.size(); i++)
       {
         new_jt_traj.points[0].positions[i] = orig_jts_.position[i];

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -174,7 +174,7 @@ JogCalcs::JogCalcs(std::string move_group_name) :
   robot_model_loader::RobotModelLoader model_loader("robot_description");
   robot_model::RobotModelPtr kinematic_model = model_loader.getModel();
 
-  kinematic_state_ = boost::shared_ptr<robot_state::RobotState>(new robot_state::RobotState(kinematic_model));
+  kinematic_state_ = std::shared_ptr<robot_state::RobotState>(new robot_state::RobotState(kinematic_model));
   kinematic_state_->setToDefaultValues();
 
   joint_model_group_ = kinematic_model->getJointModelGroup(move_group_name);
@@ -316,7 +316,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   for (int i=1; i<20; i++)
   {
     point.time_from_start = ros::Duration(i*jog_arm::pub_period);
-    new_traj.points.push_back(point);
+    new_jt_traj.points.push_back(point);
   }
 
   // Stop if imminent collision

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -307,7 +307,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   new_jt_traj.joint_names = jt_state_.name;
   trajectory_msgs::JointTrajectoryPoint point;
   point.positions = jt_state_.position;
-  point.time_from_start = ros::Durataion(jog_arm::pub_period);
+  point.time_from_start = ros::Duration(jog_arm::pub_period);
   point.velocities = jt_state_.velocity;
 
   // Spam several redundant points into the trajectory. The first few may be skipped if the

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -352,7 +352,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   {
     if ( currentCN > jog_arm::hard_stop_sing_thresh )
     {
-      ROS_ERROR_THROTTLE(2,"[jog_arm_server jogCalcs] Dangerously close to a singularity. Halting.");
+      ROS_ERROR_THROTTLE(2,"[jog_arm_server jogCalcs] Dangerously close to a singularity (%f). Halting.", currentCN);
       for (int i=0; i<jt_state_.velocity.size(); i++)
       {
         new_jt_traj.points[0].positions[i] = orig_jts_.position[i];

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -313,9 +313,15 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
 
   // Spam several redundant points into the trajectory. The first few may be skipped if the
   // time stamp is in the past when it reaches the client.
-  for (int i=1; i<20; i++)
-  {
-    point.time_from_start = ros::Duration(i*jog_arm::pub_period);
+  if (jog_arm::simu) {
+    // Spam several redundant points into the trajectory. The first few may be skipped if the
+    // time stamp is in the past when it reaches the client. Needed for gazebo simulation.
+    for (int i=1; i<30; i++)
+    {
+      point.time_from_start = ros::Duration(i*jog_arm::pub_period);
+      new_jt_traj.points.push_back(point);
+    }
+  } else {
     new_jt_traj.points.push_back(point);
   }
 
@@ -504,6 +510,8 @@ int readParams(ros::NodeHandle& n)
   ROS_INFO_STREAM("planning_frame: " << jog_arm::planning_frame);
   jog_arm::pub_period = jog_arm::getDoubleParam("jog_arm_server/pub_period", n);
   ROS_INFO_STREAM("pub_period: " << jog_arm::pub_period);
+  jog_arm::simu = jog_arm::getBoolParam("jog_arm_server/simu", n);
+  ROS_INFO_STREAM("simu: " << jog_arm::simu);
   ROS_INFO_STREAM("---------------------------------------");
   ROS_INFO_STREAM("---------------------------------------");
 
@@ -534,6 +542,14 @@ double getDoubleParam(std::string name, ros::NodeHandle& n)
   double value;
   if( !n.getParam(name, value) )
     ROS_ERROR_STREAM("[JogCalcs::getDoubleParam] YAML config file does not contain parameter " << name);
+  return value;
+}
+
+bool getBoolParam(std::string name, ros::NodeHandle& n)
+{
+  bool value;
+  if( !n.getParam(name, value) )
+    ROS_ERROR_STREAM("[JogCalcs::getBoolParam] YAML config file does not contain parameter " << name);
   return value;
 }
 

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -315,7 +315,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped& cmd)
   for (int i=1; i<20; i++)
   {
     point.time_from_start = ros::Duration(i*jog_arm::pub_period);
-    new_traj.points.push_back(point);
+    new_jt_traj.points.push_back(point);
   }
 
   // Stop if imminent collision

--- a/src/jog_arm_server.cpp
+++ b/src/jog_arm_server.cpp
@@ -108,7 +108,6 @@ void *collisionCheck(void *threadid)
 
 CollisionCheck::CollisionCheck(std::string move_group_name)
 {
-  moveit::planning_interface::MoveGroup* move_group_ptr = new moveit::planning_interface::MoveGroup(move_group_name);
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
   robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
   planning_scene::PlanningScene planning_scene(kinematic_model);


### PR DESCRIPTION
1. Merge latest changes from indigo and kinetic, fix build problems in kinetic.
2. Add "simu" configuration parameter, that toggles whether to send multiple points in the trajectory or not. 
While sending multiple points, then testing with UR5, robot stuttered while moving. On the other hand, without spamming multiple points into trajectory, simulated robot didn't move in Gazebo. Solution was to make it configurable.
3. Wait for TwistStamped jog message also, addition to JointState messages, because both are needed for moving jogging.
4. Add 1 second sleep before entering main trajectory publishing loop. Necessary, because when receiving noisy data, filter needs some cycles to stabilize. At least in Gazebo environment without this sleep, the robot jumps very suddenly at the start of moving with noisy data, seemed dangerous.

Tested on UR5 hardware and also in simulation environment, Gazebo.


