### PR TITLE
use pass-by-const-reference where applicable

### DIFF
--- a/include/jog_arm/get_ros_params.h
+++ b/include/jog_arm/get_ros_params.h
@@ -36,10 +36,10 @@
 
 namespace get_ros_params
 {
-  std::string getStringParam(std::string s, ros::NodeHandle& n);
-  double getDoubleParam(std::string name, ros::NodeHandle& n);
-  double getIntParam(std::string name, ros::NodeHandle& n);
-  bool getBoolParam(std::string name, ros::NodeHandle& n);
+  std::string getStringParam(const std::string& name, ros::NodeHandle& n);
+  double getDoubleParam(const std::string& name, ros::NodeHandle& n);
+  double getIntParam(const std::string& name, ros::NodeHandle& n);
+  bool getBoolParam(const std::string& name, ros::NodeHandle& n);
 }
 
 #endif // GET_ROS_PARAMS_H

--- a/include/jog_arm/jog_api.h
+++ b/include/jog_arm/jog_api.h
@@ -44,7 +44,7 @@
 class jog_api {
 public:
 	// Constructor
-  jog_api(std::string move_group_name) :
+  jog_api(const std::string& move_group_name) :
     move_group_(move_group_name),
     tf2_listener_(tf_buffer_)
   {
@@ -57,7 +57,7 @@ public:
     const double rot_tolerance,
     const double linear_vel_scale,
     const double rot_vel_scale,
-    ros::Duration timeout);
+    const ros::Duration& timeout);
 
 private:
 	ros::NodeHandle nh_;

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -140,7 +140,7 @@ double lpf::filter(const double& new_msrmt)
 class JogCalcs
 {
 public:
-  JogCalcs(std::string move_group_name);
+  JogCalcs(const std::string& move_group_name);
   
 protected:
   moveit::planning_interface::MoveGroupInterface arm_;
@@ -190,7 +190,7 @@ protected:
 class CollisionCheck
 {
 public:
-    CollisionCheck(std::string move_group_name);
+    CollisionCheck(const std::string &move_group_name);
 };
 
 } // namespace jog_arm

--- a/src/jog_arm/get_ros_params.cpp
+++ b/src/jog_arm/get_ros_params.cpp
@@ -30,14 +30,15 @@
 
 #include "jog_arm/get_ros_params.h"
 
-std::string get_ros_params::getStringParam(std::string s, ros::NodeHandle& n)
+std::string get_ros_params::getStringParam(const std::string& name, ros::NodeHandle& n)
 {
-  if( !n.getParam(s, s) )
+  std::string s;
+  if( !n.getParam(name, s) )
     ROS_ERROR_STREAM("[JogCalcs::getStringParam] YAML config file does not contain parameter " << s);
   return s;
 }
 
-double get_ros_params::getDoubleParam(std::string name, ros::NodeHandle& n)
+double get_ros_params::getDoubleParam(const std::string& name, ros::NodeHandle& n)
 {
   double value;
   if( !n.getParam(name, value) )
@@ -45,7 +46,7 @@ double get_ros_params::getDoubleParam(std::string name, ros::NodeHandle& n)
   return value;
 }
 
-double get_ros_params::getIntParam(std::string name, ros::NodeHandle& n)
+double get_ros_params::getIntParam(const std::string& name, ros::NodeHandle& n)
 {
   int value;
   if( !n.getParam(name, value) )
@@ -53,7 +54,7 @@ double get_ros_params::getIntParam(std::string name, ros::NodeHandle& n)
   return value;
 }
 
-bool get_ros_params::getBoolParam(std::string name, ros::NodeHandle& n)
+bool get_ros_params::getBoolParam(const std::string& name, ros::NodeHandle& n)
 {
   bool value;
   if( !n.getParam(name, value) )

--- a/src/jog_arm/jog_api.cpp
+++ b/src/jog_arm/jog_api.cpp
@@ -42,7 +42,7 @@ bool jog_api::jacobian_move(geometry_msgs::PoseStamped& target_pose,
   const double rot_tolerance,
   const double linear_vel_scale,
   const double rot_vel_scale,
-  ros::Duration timeout)
+  const ros::Duration& timeout)
 {
   // Velocity scaling should be between 0 and 1
   if ( 0.>linear_vel_scale || 1.<linear_vel_scale )

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -126,13 +126,13 @@ void *collisionCheck(void *)
 }
 
 // Constructor for the class that handles collision checking
-CollisionCheck::CollisionCheck(std::string move_group_name)
+CollisionCheck::CollisionCheck(const std::string &move_group_name)
 {
   // If user specified true in yaml file
   if (jog_arm::coll_check)
   {
     robot_model_loader::RobotModelLoader robot_model_loader("robot_description");
-    robot_model::RobotModelPtr kinematic_model = robot_model_loader.getModel();
+    const robot_model::RobotModelPtr& kinematic_model = robot_model_loader.getModel();
     planning_scene::PlanningScene planning_scene(kinematic_model);
     collision_detection::CollisionRequest collision_request;
     collision_request.group_name = move_group_name;
@@ -190,12 +190,12 @@ CollisionCheck::CollisionCheck(std::string move_group_name)
 }
 
 // Constructor for the class that handles jogging calculations
-JogCalcs::JogCalcs(std::string move_group_name) :
+JogCalcs::JogCalcs(const std::string& move_group_name) :
   arm_(move_group_name)
 {
   /** MoveIt Setup **/
   robot_model_loader::RobotModelLoader model_loader("robot_description");
-  robot_model::RobotModelPtr kinematic_model = model_loader.getModel();
+  const robot_model::RobotModelPtr& kinematic_model = model_loader.getModel();
 
   kinematic_state_ = std::shared_ptr<robot_state::RobotState>(new robot_state::RobotState(kinematic_model));
   kinematic_state_->setToDefaultValues();


### PR DESCRIPTION
Note that `getStringParam` was a little bit weird since the `s` parameter was reused as an output variable.