### PR TITLE
Fix jog application of joint limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,3 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(${PROJECT_NAME}_utest test/launch/utest.launch ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest ${catkin_LIBRARIES} ${Boost_LIBRARIES} compliant_control)
 endif()
-
-#####################
-# QTCREATOR / CLION #
-#####################
-FILE(GLOB_RECURSE LibFiles "include/*")
-add_custom_target(headers SOURCES ${LibFiles})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,3 +70,9 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(${PROJECT_NAME}_utest test/launch/utest.launch ${UTEST_SRC_FILES})
   target_link_libraries(${PROJECT_NAME}_utest ${catkin_LIBRARIES} ${Boost_LIBRARIES} compliant_control)
 endif()
+
+#####################
+# QTCREATOR / CLION #
+#####################
+FILE(GLOB_RECURSE LibFiles "include/*")
+add_custom_target(headers SOURCES ${LibFiles})

--- a/config/jog_settings.yaml
+++ b/config/jog_settings.yaml
@@ -11,9 +11,9 @@ jog_arm_server:
   command_out_topic:  sia5_controller/command
   planning_frame:  base_link  # The MoveIt! planning frame. Often 'base_link'
   low_pass_filter_coeff:  2.  # Larger --> trust the filtered data more, trust the measurements less.
-  publish_period:  0.01  # 1/Nominal publish rate [seconds]
+  publish_period:  0.008  # 1/Nominal publish rate [seconds]
   scale:
-    linear:  0.0004  # Max linear velocity. Meters per publish_period. Units is [m/s]
-    rotational:  0.0008  # Max angular velocity. Rads per publish_period. Units is [rad/s]
+    linear:  0.0016  # Max linear velocity. Meters per publish_period. Units is [m/s]
+    rotational:  0.0032  # Max angular velocity. Rads per publish_period. Units is [rad/s]
   # Publish boolean warnings to this topic
   warning_topic:  jog_arm_server/warning

--- a/include/jog_arm/compliant_control.h
+++ b/include/jog_arm/compliant_control.h
@@ -137,8 +137,8 @@ private:
 
 class LowPassFilter {
 public:
-  LowPassFilter(double filter_param);
-  double filter(const double new_msrmt);
+  explicit LowPassFilter(double filter_param);
+  double filter(double new_msrmt);
 
   // Related to the cutoff frequency of the filter.
   // filter_param=1 results in a cutoff at 1/4 of the sampling rate.

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -195,9 +195,6 @@ protected:
   bool addJointIncrements(sensor_msgs::JointState &output,
                           const Eigen::VectorXd &increments) const;
 
-  bool updateJointVels(sensor_msgs::JointState &output,
-                       const Eigen::VectorXd &joint_vels) const;
-
   double checkConditionNumber(const Eigen::MatrixXd &matrix) const;
 
   // Reset the data stored in low-pass filters so the trajectory won't jump when

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -44,7 +44,7 @@
 
 #include <Eigen/Eigenvalues>
 #include <geometry_msgs/Twist.h>
-#include <math.h>
+#include <cmath>
 #include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
@@ -121,8 +121,8 @@ private:
  */
 class LowPassFilter {
 public:
-  LowPassFilter(double low_pass_filter_coeff);
-  double filter(const double new_msrmt);
+  explicit LowPassFilter(double low_pass_filter_coeff);
+  double filter(double new_msrmt);
   void reset(double data);
   double filter_coeff_ = 10.;
 
@@ -131,11 +131,11 @@ private:
   double prev_filtered_msrmts_[2] = {0., 0.};
 };
 
-LowPassFilter::LowPassFilter(double low_pass_filter_coeff) {
+LowPassFilter::LowPassFilter(const double low_pass_filter_coeff) {
   filter_coeff_ = low_pass_filter_coeff;
 }
 
-void LowPassFilter::reset(double data) {
+void LowPassFilter::reset(const double data) {
   prev_msrmts_[0] = data;
   prev_msrmts_[1] = data;
   prev_msrmts_[2] = data;
@@ -221,9 +221,6 @@ protected:
 
   std::vector<jog_arm::LowPassFilter> velocity_filters_;
   std::vector<jog_arm::LowPassFilter> position_filters_;
-
-  // Check whether incoming cmds are stale. Pause if so
-  ros::Duration time_of_incoming_cmd_;
 
   ros::Publisher warning_pub_;
 

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -230,7 +230,7 @@ protected:
    *  Verify that the future Jacobian is well-conditioned before moving.
    *  Slow down if very close to a singularity.
    *  Stop if extremely close.
-   * @return true of Jacobian is well conditioned, false if not
+   * @return true if Jacobian is well conditioned, false if not
    */
   bool verifyJacobianIsWellConditioned(
     const Eigen::MatrixXd &old_jacobian, const Eigen::VectorXd &delta_theta,

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -69,9 +69,6 @@ struct jog_arm_shared {
   sensor_msgs::JointState joints;
   pthread_mutex_t joints_mutex;
 
-  trajectory_msgs::JointTrajectory new_traj;
-  pthread_mutex_t new_traj_mutex;
-
   bool imminent_collision;
   pthread_mutex_t imminent_collision_mutex;
 
@@ -90,7 +87,7 @@ struct jog_arm_parameters {
 };
 
 /**
- * Class jogROSInterface - Instantiated in main(). Handles ROS subs & pubs.
+ * Class jogROSInterface - Instantiated in main(). Handles ROS subs & pubs and creates the worker threads.
  */
 class jogROSInterface {
 public:
@@ -180,6 +177,8 @@ protected:
   geometry_msgs::TwistStamped cmd_deltas_;
 
   sensor_msgs::JointState incoming_jts_;
+
+  trajectory_msgs::JointTrajectory new_traj_;
 
   void jogCalcs(const geometry_msgs::TwistStamped &cmd,
                 jog_arm_shared &shared_variables);

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -225,17 +225,34 @@ protected:
   ros::Publisher warning_pub_;
 
   jog_arm_parameters parameters_;
+
+  void publishWarning(const bool active) const;
+
+  bool checkIfJointsWithinBounds(
+    trajectory_msgs::JointTrajectory_ <std::allocator<void>> &new_jt_traj
+  );
+
+  /**
+   *  Verify that the future Jacobian is well-conditioned before moving.
+   *  Slow down if very close to a singularity.
+   *  Stop if extremely close.
+   * @return true of Jacobian is well conditioned, false if not
+   */
+  bool verifyJacobianIsWellConditioned(
+    const Eigen::MatrixXd &old_jacobian, const Eigen::VectorXd &delta_theta,
+    const Eigen::MatrixXd &new_jacobian, trajectory_msgs::JointTrajectory &new_jt_traj
+  );
+
+  bool checkIfImminentCollision(
+    jog_arm_shared &shared_variables,
+    trajectory_msgs::JointTrajectory &new_jt_traj
+  );
 };
 
 class CollisionCheck {
 public:
   CollisionCheck(const jog_arm_parameters &parameters,
                  jog_arm_shared &shared_variables);
-
-private:
-  ros::NodeHandle nh_;
-
-  ros::Publisher warning_pub_;
 };
 
 } // namespace jog_arm

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -212,14 +212,11 @@ protected:
 
   tf::TransformListener listener_;
 
-  ros::Time prev_time_;
-
-  double delta_t_;
-
   std::vector<jog_arm::LowPassFilter> velocity_filters_;
   std::vector<jog_arm::LowPassFilter> position_filters_;
 
   ros::Publisher warning_pub_;
+  ros::Publisher joint_trajectory_pub_;
 
   jog_arm_parameters parameters_;
 

--- a/include/jog_arm/jog_arm_server.h
+++ b/include/jog_arm/jog_arm_server.h
@@ -226,7 +226,7 @@ protected:
 
   jog_arm_parameters parameters_;
 
-  void publishWarning(const bool active) const;
+  void publishWarning(bool active) const;
 
   bool checkIfJointsWithinBounds(
     trajectory_msgs::JointTrajectory_ <std::allocator<void>> &new_jt_traj
@@ -247,6 +247,10 @@ protected:
     jog_arm_shared &shared_variables,
     trajectory_msgs::JointTrajectory &new_jt_traj
   );
+
+  trajectory_msgs::JointTrajectory
+  composeOutgoingMessage(sensor_msgs::JointState &joint_state,
+                         const ros::Time &stamp) const;
 };
 
 class CollisionCheck {

--- a/launch/jog_with_xbox.launch
+++ b/launch/jog_with_xbox.launch
@@ -4,7 +4,7 @@
 
   <node name="joy_node" pkg="joy" type="joy_node" />
 
-  <node name="joy_to_twist" pkg="jog_arm" type="joy_to_twist" output="screen" />
+  <node name="xbox_to_twist" pkg="jog_arm" type="xbox_to_twist" output="screen" />
 
   <node name="jog_arm_server" pkg="jog_arm" type="jog_arm_server" output="screen" />
 

--- a/src/jog_arm/compliant_control/compliant_control.cpp
+++ b/src/jog_arm/compliant_control/compliant_control.cpp
@@ -195,7 +195,7 @@ CompliantControl::getVelocity(std::vector<double> v_in,
   return exitCondition;
 }
 
-LowPassFilter::LowPassFilter(double filter_param)
+LowPassFilter::LowPassFilter(const double filter_param)
     : filter_param_(filter_param) {}
 
 double LowPassFilter::filter(const double new_msrmt) {

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -75,12 +75,20 @@ jogROSInterface::jogROSInterface() {
   int rc = pthread_create(
     &joggingThread, nullptr, jog_arm::jogROSInterface::joggingPipeline, this
   );
+  if (rc) {
+    ROS_FATAL_NAMED("jog_arm_server", "Creating pipeline thread failed", rc);
+    return;
+  }
 
   // Check collisions in this thread
   pthread_t collisionThread;
   rc = pthread_create(
     &collisionThread, nullptr, jog_arm::jogROSInterface::collisionCheck, this
   );
+  if (rc) {
+    ROS_FATAL_NAMED("jog_arm_server", "Creating collision check failed", rc);
+    return;
+  }
 
   // ROS subscriptions. Share the data with the worker threads
   ros::Subscriber cmd_sub = n.subscribe(ros_parameters_.command_in_topic, 1,

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -227,7 +227,7 @@ CollisionCheck::CollisionCheck(const jog_arm_parameters &parameters,
         shared_variables.imminent_collision = true;
         pthread_mutex_unlock(&shared_variables.imminent_collision_mutex);
 
-        collision_status.data = true;
+        collision_status.data = static_cast<std_msgs::Bool::_data_type >(true);
         warning_pub_.publish(collision_status);
       } else {
         pthread_mutex_lock(&shared_variables.imminent_collision_mutex);
@@ -480,7 +480,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
       halt(new_jt_traj);
 
       std_msgs::Bool singularity_status;
-      singularity_status.data = true;
+      singularity_status.data = static_cast<std_msgs::Bool::_data_type >(true);
       warning_pub_.publish(singularity_status);
     }
     // Only somewhat close to singularity. Just slow down.
@@ -504,7 +504,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
     halt(new_jt_traj);
 
     std_msgs::Bool limit_status;
-    limit_status.data = true;
+    limit_status.data = static_cast<std_msgs::Bool::_data_type >(true);
     warning_pub_.publish(limit_status);
   }
 

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -526,9 +526,9 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
 // Halt the robot
 void JogCalcs::halt(trajectory_msgs::JointTrajectory &jt_traj) {
   for (std::size_t i = 0; i < jt_state_.velocity.size(); ++i) {
-    jt_traj.points[0].positions[i] = orig_jts_.position[i];
     jt_traj.points[0].velocities[i] = 0.;
   }
+  jt_traj.points[0].positions.clear();
   // Store all zeros in the velocity filter
   resetVelocityFilters();
 }

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -404,10 +404,6 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
   if (!addJointIncrements(jt_state_, delta_theta))
     return;
 
-  // Check the Jacobian with these new joints.
-  kinematic_state_->setVariableValues(jt_state_);
-  Eigen::MatrixXd jacobian = kinematic_state_->getJacobian(joint_model_group_);
-
   // Include a velocity estimate for velocity-controller robots
   Eigen::VectorXd joint_vel(delta_theta / delta_t_);
 
@@ -430,6 +426,10 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
     if (std::isnan(jt_state_.position[i]))
       jt_state_.position[i] = orig_jts_.position[i];
   }
+
+   // Check the Jacobian with these new joints.
+  kinematic_state_->setVariableValues(jt_state_);
+  Eigen::MatrixXd jacobian = kinematic_state_->getJacobian(joint_model_group_);
 
   // Compose the outgoing msg
   trajectory_msgs::JointTrajectory new_jt_traj;

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -399,12 +399,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
   // expectations.
   delta_t_ = (ros::Time::now() - prev_time_).toSec();
   prev_time_ = ros::Time::now();
-  delta_theta[0] *= parameters_.publish_period / delta_t_;
-  delta_theta[1] *= parameters_.publish_period / delta_t_;
-  delta_theta[2] *= parameters_.publish_period / delta_t_;
-  delta_theta[3] *= parameters_.publish_period / delta_t_;
-  delta_theta[4] *= parameters_.publish_period / delta_t_;
-  delta_theta[5] *= parameters_.publish_period / delta_t_;
+  delta_theta *= parameters_.publish_period / delta_t_;
 
   if (!addJointIncrements(jt_state_, delta_theta))
     return;

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -54,8 +54,7 @@ jog_arm::jog_arm_shared jog_arm::jogROSInterface::shared_variables_;
 
 static const char *const NODE_NAME = "jog_arm_server";
 
-// MAIN: create the worker threads and subscribe to jogging cmds and joint
-// angles
+// MAIN
 int main(int argc, char **argv) {
   ros::init(argc, argv, NODE_NAME);
 

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -448,7 +448,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
   bool collision = shared_variables.imminent_collision;
   pthread_mutex_unlock(&shared_variables.imminent_collision_mutex);
   if (collision) {
-    ROS_ERROR_STREAM_THROTTLE_NAMED(2, "jog_arm_server",
+    ROS_WARN_STREAM_THROTTLE_NAMED(2, "jog_arm_server",
                                     ros::this_node::getName()
                                         << " Close to a collision. "
                                            "Halting.");
@@ -465,7 +465,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
     && (current_condition_number > old_condition_number)) {
     if (current_condition_number >
         parameters_.hard_stop_singularity_threshold) {
-      ROS_ERROR_STREAM_THROTTLE_NAMED(1, "jog_arm_server",
+      ROS_WARN_STREAM_THROTTLE_NAMED(1, "jog_arm_server",
                                       ros::this_node::getName()
                                           << " Close to a "
                                              "singularity ("
@@ -491,7 +491,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
 
   // Check if new joints would be within bounds
   if (!kinematic_state_->satisfiesBounds(joint_model_group_)) {
-    ROS_ERROR_STREAM_THROTTLE_NAMED(
+    ROS_WARN_STREAM_THROTTLE_NAMED(
         2, "jog_arm_server", ros::this_node::getName()
                                  << " Close to a "
                                     "position or velocity limit. Halting.");

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -653,8 +653,8 @@ void jogROSInterface::deltaCmdCB(
       shared_variables_.command_deltas.twist.linear.y == 0.0 &&
       shared_variables_.command_deltas.twist.linear.z == 0.0 &&
       shared_variables_.command_deltas.twist.angular.x == 0.0 &&
-      shared_variables_.command_deltas.twist.linear.y == 0.0 &&
-      shared_variables_.command_deltas.twist.linear.z == 0.0;
+      shared_variables_.command_deltas.twist.angular.y == 0.0 &&
+      shared_variables_.command_deltas.twist.angular.z == 0.0;
   pthread_mutex_unlock(&shared_variables_.zero_trajectory_flag_mutex);
 }
 

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -548,9 +548,9 @@ void JogCalcs::publishWarning(const bool active) const {
 // Halt the robot
 void JogCalcs::halt(trajectory_msgs::JointTrajectory &jt_traj) {
   for (std::size_t i = 0; i < jt_state_.velocity.size(); ++i) {
+    jt_traj.points[0].positions[i] = orig_jts_.position[i];
     jt_traj.points[0].velocities[i] = 0.;
   }
-  jt_traj.points[0].positions.clear();
   // Store all zeros in the velocity filter
   resetVelocityFilters();
 }

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -416,7 +416,7 @@ void JogCalcs::jogCalcs(const geometry_msgs::TwistStamped &cmd,
 
     // Check for nan's
     if (std::isnan(jt_state_.position[i]))
-      jt_state_.position[i] = 0.;
+      jt_state_.position[i] = orig_jts_.position[i];
   }
 
   // Compose the outgoing msg

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -605,7 +605,7 @@ bool JogCalcs::addJointIncrements(sensor_msgs::JointState &output,
   for (std::size_t i = 0, size = static_cast<std::size_t>(increments.size());
        i < size; ++i) {
     try {
-      output.position[i] += increments(static_cast<long>(i));
+      output.position[i] += increments[static_cast<long>(i)];
     } catch (const std::out_of_range &e) {
       ROS_ERROR_STREAM_NAMED("jog_arm_server",
                              ros::this_node::getName()

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -722,10 +722,10 @@ int jogROSInterface::readParameters(ros::NodeHandle &n) {
   error += !rosparam_shortcuts::get(
       "", n, parameter_ns + "/jog_arm_server/gazebo", ros_parameters_.gazebo);
   error +=
-      !rosparam_shortcuts::get("", n, parameter_ns + "/jog_arm_server/gazebo",
+      !rosparam_shortcuts::get("", n, parameter_ns + "/jog_arm_server/collision_check",
                                ros_parameters_.collision_check);
   error +=
-      !rosparam_shortcuts::get("", n, parameter_ns + "/jog_arm_server/gazebo",
+      !rosparam_shortcuts::get("", n, parameter_ns + "/jog_arm_server/warning_topic",
                                ros_parameters_.warning_topic);
 
   ROS_INFO_STREAM_NAMED("jog_arm_server",

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -52,12 +52,10 @@ jog_arm::jog_arm_shared jog_arm::jogROSInterface::shared_variables_;
 // Another worker thread does collision checking.
 /////////////////////////////////////////////////
 
-static const char *const NODE_NAME = "jog_arm_server";
-
 // MAIN: create the worker threads and subscribe to jogging cmds and joint
 // angles
 int main(int argc, char **argv) {
-  ros::init(argc, argv, NODE_NAME);
+  ros::init(argc, argv, "jog_arm_server");
 
   jog_arm::jogROSInterface ros_interface;
 

--- a/src/jog_arm/jog_arm_server.cpp
+++ b/src/jog_arm/jog_arm_server.cpp
@@ -52,10 +52,12 @@ jog_arm::jog_arm_shared jog_arm::jogROSInterface::shared_variables_;
 // Another worker thread does collision checking.
 /////////////////////////////////////////////////
 
+static const char *const NODE_NAME = "jog_arm_server";
+
 // MAIN: create the worker threads and subscribe to jogging cmds and joint
 // angles
 int main(int argc, char **argv) {
-  ros::init(argc, argv, "jog_arm_server");
+  ros::init(argc, argv, NODE_NAME);
 
   jog_arm::jogROSInterface ros_interface;
 

--- a/src/jog_arm/xbox_to_twist.cpp
+++ b/src/jog_arm/xbox_to_twist.cpp
@@ -42,7 +42,7 @@ private:
 } // end to_twist namespace
 
 int main(int argc, char **argv) {
-  ros::init(argc, argv, "spacenav_to_twist");
+  ros::init(argc, argv, "xbox_to_twist");
 
   to_twist::xboxToTwist to_twist;
 


### PR DESCRIPTION
This PR fixes some problems when the robot arm hit joint limits. Previously, it was possible to overdrive the joint limits in some instance. Additionally, jogging was halted when a velocity limit was hit. This resulted in unsmooth movement, even when the target position was correct.

To fix this problem, I applied the joint velocity limits when a limit is hit. When the position limit is hit, the jogging is stopped.

Additionally, now the calculation is stopped when no jog input is received.

Furthermore, I fixed some bugs:
* 2 params where not correctly initialized
* warning topic did not work
* pthread return values were not checked
* xbox_to_twist launch file was incorrect and node name as well

Moreover, I applied code style and quality fix where applicable.

Note: I still encounter a problem when stopping jogging, I will fix this tomorrow, I just wanted to get this PR out in case anyone else is working these problems as well, to prevent double work.