### PR TITLE
Enable Industrial CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ env:
     - ROS_REPO=ros
   matrix:
     - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
-    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
-matrix:
-  allow_failures:
-    - env: ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
-    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
+#    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
+#matrix:
+#  allow_failures:
+#    - env: ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+#    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+dist: trusty
+language: generic
+notifications:
+  email:
+    on_success: change
+    on_failure: always
+env:
+  global:
+    - ROS_REPO=ros
+  matrix:
+    - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
+matrix:
+  allow_failures:
+    - env: ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
+install:
+  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+script:
+  - .ci_config/travis.sh
+#  - ./travis.sh  # Enable this when you have a package-local script
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,6 @@ if(CATKIN_ENABLE_TESTING)
   set(UTEST_SRC_FILES test/utest.cpp
       test/compliant_control.cpp)
 
-  add_rostest_gtest(${PROJECT_NAME}_utest test/launch/utest.launch ${UTEST_SRC_FILES})
-  target_link_libraries(${PROJECT_NAME}_utest ${catkin_LIBRARIES} ${Boost_LIBRARIES} compliant_control)
+  add_rostest_gtest(compliant_control_utest test/launch/utest.launch ${UTEST_SRC_FILES})
+  target_link_libraries(compliant_control_utest ${catkin_LIBRARIES} ${Boost_LIBRARIES} compliant_control)
 endif()

--- a/package.xml
+++ b/package.xml
@@ -33,4 +33,5 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <depend>tf2_geometry_msgs</depend>
+  <test_depend>rostest</test_depend>
 </package>

--- a/test/launch/utest.launch
+++ b/test/launch/utest.launch
@@ -10,8 +10,8 @@
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --ex run --args" />
 
   <!-- Test Node -->
-  <test test-name="compliant_control_utest" pkg="moveit_experimental" type="compliant_control_utest"
+  <test test-name="compliant_control_utest" pkg="jog_arm" type="compliant_control_utest"
     launch-prefix="$(arg launch_prefix)" if="$(arg run_test_node)" time-limit = "200.0">
   </test>
-  
+
 </launch>


### PR DESCRIPTION
This PR enables the [industrial-ci](https://github.com/ros-industrial/industrial_ci) for `jog_arm`.

You need to enable travis-ci for this repository. (see https://github.com/ros-industrial/industrial_ci#id5)